### PR TITLE
Update README.md

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -8,7 +8,7 @@ Cipher: AES/256/CBC/PKCS5Padding with random generated salt
 ### Usage
 
 ```go
-import "./aes256"
+import "github.com/johnjjung/go-aes256"
 
 // encryption
 aes256.Encrypt("TEXT", "PASSWORD")


### PR DESCRIPTION
Should not import by reference

TODO:
- automate with travis to copy file to another hosted repo for aes-everywhere

Asking for suggestions on:
- how to copy aes-everywhere/go to another github repo
- what to name that repo

I just copied the current aes256.go file and put it in this repo

https://github.com/johnjjung/go-aes256