### PR TITLE
Add lua support (openssl)

### DIFF
--- a/lua/README.md
+++ b/lua/README.md
@@ -1,0 +1,20 @@
+# AES Everywhere - Cross Language Encryption Library
+
+Cipher: AES/256/CBC/PKCS7Padding with random generated salt
+
+## Lua implementation
+
+Requirements: openssl
+
+### Usage
+
+```lua
+AES256 = require("aes256")
+
+-- encryption
+local enc = AES256.encrypt('TEXT', 'PASSWORD')
+
+-- decryption
+local dec = AES256.decrypt('ENCRYPTED', 'PASSWORD')
+```
+

--- a/lua/src/aes256.lua
+++ b/lua/src/aes256.lua
@@ -1,0 +1,28 @@
+-- Requires openssl command line program
+
+AES256 = {}
+
+AES256.cmd = "echo '%s' | " ..
+        "openssl enc -aes-256-cbc -md md5 -a -A -pass pass:'%s'"
+
+AES256.encrypt = function(text, passphrase)
+    local handle = io.popen(string.format(AES256.cmd, text, passphrase))
+    local result = handle:read("*a")
+    handle:close()
+    return result
+end
+
+AES256.decrypt = function(encrypt, passphrase)
+    local cmd = AES256.cmd .. " -d"
+    local handle = io.popen(string.format(cmd, encrypt, passphrase))
+    local result = handle:read("*a")
+    handle:close()
+    -- check for newline at the end of the string
+    local last_char = string.sub(result, -1)
+    if (last_char == '\n') then
+        result = string.sub(result, 0, string.len(result)-1)
+    end
+    return result
+end
+
+return AES256;

--- a/lua/src/aes256.lua
+++ b/lua/src/aes256.lua
@@ -1,3 +1,31 @@
+-- aes256.lua
+-- This file is part of AES-everywhere project (https://github.com/mervick/aes-everywhere)
+--
+-- This is an implementation of the AES algorithm, specifically CBC mode,
+-- with 256 bits key length and PKCS7 padding.
+--
+-- Copyright Andrey Izman (c) 2018-2019 <izmanw@gmail.com>
+-- Copyright Philip Mayer (c) 2020 <philip.mayer@shadowsith.de>
+-- Licensed under the MIT license
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
 -- Requires openssl command line program
 
 AES256 = {}

--- a/powershell/src/aes256.ps1
+++ b/powershell/src/aes256.ps1
@@ -36,9 +36,6 @@ param (
     [switch]$h
 )
 
-
-# Write-Host "NAME" -Color Red
-
 $small_help = "usage: aes256 [-m encrypt (default)|decrypt] [-t text] [-p passphrase]
 `t[-i input_file] [-o output_file]"
 


### PR DESCRIPTION
I've added Lua support for aes-everywhere with the help of the openssl command line program.
There are some AES implementations for Lua but all of them are linked to some shared object (.so) libraries and I'm not sure if one of them fit for this project. 
I also think it is completely adequate for small Lua scripts to use openssl.

The implementation is a static class like them for PHP.

I've also removed a comment in the powershell file which  I've forgotten to delete before the first pull request.