### PR TITLE
update lua implementation (native)

### DIFF
--- a/lua/README.md
+++ b/lua/README.md
@@ -4,7 +4,7 @@ Cipher: AES/256/CBC/PKCS7Padding with random generated salt
 
 ## Lua implementation
 
-Requirements: luarocks (lua package manager)
+Requirements: luarocks (lua package manager)<br>
 `luarocks install openssl`
 
 ### Usage

--- a/lua/README.md
+++ b/lua/README.md
@@ -4,7 +4,8 @@ Cipher: AES/256/CBC/PKCS7Padding with random generated salt
 
 ## Lua implementation
 
-Requirements: openssl
+Requirements: luarocks (lua package manager)
+`luarocks install openssl`
 
 ### Usage
 

--- a/lua/README.md
+++ b/lua/README.md
@@ -10,7 +10,7 @@ Requirements: luarocks (lua package manager)<br>
 ### Usage
 
 ```lua
-AES256 = require("aes256")
+local AES256 = require("aes256")
 
 -- encryption
 local enc = AES256.encrypt('TEXT', 'PASSWORD')


### PR DESCRIPTION
After a bit of research I've found a native openssl implementation for lua.
I've testet it and it works very well with the other aes-everywhere languages.

If you want test it too you only have to install luarocks and the luarocks package openssl.
`(sudo) luarocks install openssl`