### PR TITLE
fix wrong return type annotation

### DIFF
--- a/python/src/AesEverywhere/aes256.py
+++ b/python/src/AesEverywhere/aes256.py
@@ -52,7 +52,7 @@ def encrypt(raw, passphrase):
     @param passphrase: string Passphrase
     @type raw: string
     @type passphrase: string
-    @rtype: string
+    @rtype: bytes
     """
     salt = Random.new().read(8)
     key, iv = __derive_key_and_iv(passphrase, salt)

--- a/python/src/tests/test_aes256.py
+++ b/python/src/tests/test_aes256.py
@@ -58,6 +58,10 @@ class TestAes256(unittest.TestCase):
         dec = aes256.decrypt(enc, passw)
         self.assertEqual(u(text), dec, FAIL)
 
+    def test_encrypt_return_type(self):
+        enc_text = aes256.encrypt("Test! @#$%^&*( 😆😵🤡👌 哈罗 こんにちわ Акїў 😺", "pass")
+        self.assertIsInstance(enc_text, bytes)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fix wrong return type annotation in encrypt function's docstring
In python2, it isn't wrong(str == bytes in python2) but this annotation is wrong in python3 (str != bytes in python3)
So, Pycharm display a warning that ```Unresolved attribute reference 'decode' for class 'str' ```